### PR TITLE
Lazy arrays

### DIFF
--- a/atuproot/BEvents.py
+++ b/atuproot/BEvents.py
@@ -21,12 +21,12 @@ class BEvents(object):
         )
 
         nblocks = int((self.nevents_in_tree-1)/self.nevents_per_block + 1)
-        start_block = min(nblocks, start_block)
-        if stop_block > -1:
-            self.nblocks = min(nblocks-start_block, stop_block)
+        start_block = min(nblocks, config.start_block)
+        if config.stop_block > -1:
+            self.nblocks = min(nblocks-start_block, config.stop_block)
         else:
             self.nblocks = nblocks-start_block
-        self.stop_block = stop_block
+        self.stop_block = config.stop_block
         self.start_block = start_block
         self.iblock = -1
 
@@ -114,7 +114,7 @@ class BEvents(object):
             self.nevents_in_tree,
         )
         self.size = self.stop_entry - self.start_entry
-        return getattr(self.tree[self.start_entry, self.stop_entry], name)
+        return getattr(self.tree[self.start_entry:self.stop_entry], name)
 
     def hasbranch(self, branch):
         return (

--- a/atuproot/BEvents.py
+++ b/atuproot/BEvents.py
@@ -1,6 +1,7 @@
 import mmap
 import numpy as np
 import awkward as awk
+import uproot
 
 class BEvents(object):
     non_branch_attrs = [

--- a/atuproot/BEvents.py
+++ b/atuproot/BEvents.py
@@ -1,11 +1,21 @@
+import operator
+from cachetools import cachedmethod
+from cachetools.keys import hashkey
+from functools import partial
+
+import numpy as np
+import awkward as awk
+
 class BEvents(object):
-    non_branch_attrs = ["tree", "nevents_in_tree", "nevents_per_block",
-                        "nblocks", "start_block", "stop_block", "iblock",
-                        "start_entry", "stop_entry", "_branch_cache",
-                        "_callable_cache", "size", "config"]
-    def __init__(self, tree,
-                 nevents_per_block=100000,
-                 start_block=0, stop_block=-1):
+    non_branch_attrs = [
+        "tree", "nevents_in_tree", "nevents_per_block", "nblocks",
+        "start_block", "stop_block", "iblock", "start_entry", "stop_entry",
+        "_branch_cache", "_nonbranch_cache", "size", "config",
+    ]
+    def __init__(
+        self, tree, nevents_per_block=100000, start_block=0, stop_block=-1,
+        branch_cache = {},
+    ):
         self.tree = tree
         self.nevents_in_tree = len(tree)
         self.nevents_per_block = int(nevents_per_block) \
@@ -22,8 +32,8 @@ class BEvents(object):
         self.start_block = start_block
         self.iblock = -1
 
-        self._branch_cache = {}
-        self._callable_cache = {}
+        self._branch_cache = branch_cache
+        self._nonbranch_cache = {}
 
     def __len__(self):
         return self.nblocks
@@ -51,64 +61,61 @@ class BEvents(object):
         if i >= self.nblocks:
             self.iblock = -1
             raise IndexError("The index is out of range: " + str(i))
-        self._branch_cache = {}
+        self._branch_cache.clear()
 
         self.iblock = i
         return self
 
     def __iter__(self):
         for self.iblock in range(self.nblocks):
-            self._branch_cache = {}
+            self._branch_cache.clear()
             yield self
         self.iblock = -1
-        self._callable_cache = {}
+        self._nonbranch_cache = {}
 
     def __getattr__(self, attr):
         if attr in self.non_branch_attrs:
             return getattr(self, attr)
+        elif attr in self._nonbranch_cache:
+            return self._nonbranch_cache[attr]
         return self._get_branch(attr)
 
     def __setattr__(self, attr, val):
         if attr in self.non_branch_attrs:
             super(BEvents, self).__setattr__(attr, val)
         else:
-            if callable(val):
-                self._callable_cache[attr] = val
+            if not (isinstance(val, awk.JaggedArray) or isinstance(val, np.ndarray)):
+                self._nonbranch_cache[attr] = val
             else:
-                self._branch_cache[attr] = val
+                key = hashkey('BEvents._get_branch', attr)
+                self._branch_cache[key] = val
 
+    @cachedmethod(operator.attrgetter('_branch_cache'), key=partial(hashkey, 'BEvents._get_branch'))
     def _get_branch(self, name):
-        if name in self._branch_cache:
-            branch = self._branch_cache[name]
-        elif name in self._callable_cache:
-            branch = self._callable_cache[name]
-        else:
-            self.start_entry = (self.start_block + self.iblock) * self.nevents_per_block
-            self.stop_entry= min(
-                (self.start_block + self.iblock + 1) * self.nevents_per_block,
-                (self.start_block + self.nblocks) * self.nevents_per_block,
-                self.nevents_in_tree,
+        self.start_entry = (self.start_block + self.iblock) * self.nevents_per_block
+        self.stop_entry= min(
+            (self.start_block + self.iblock + 1) * self.nevents_per_block,
+            (self.start_block + self.nblocks) * self.nevents_per_block,
+            self.nevents_in_tree,
+        )
+        self.size = self.stop_entry - self.start_entry
+        try:
+            branch = self.tree.array(
+                name,
+                entrystart = self.start_entry,
+                entrystop = self.stop_entry,
             )
-            self.size = self.stop_entry - self.start_entry
-            try:
-                branch = self.tree.array(
-                    name,
-                    entrystart = self.start_entry,
-                    entrystop = self.stop_entry,
-                )
-            except KeyError as e:
-                raise AttributeError(e)
-            self._branch_cache[name] = branch
+        except KeyError as e:
+            raise AttributeError(e)
         return branch
 
     def hasbranch(self, branch):
-        return (branch in self.tree.keys() or branch in self._branch_cache or branch in self._callable_cache)
+        return (branch in self.tree.keys() or branch in self._branch_cache or branch in self._nonbranch_cache)
 
     def delete_branches(self, branches):
         for branch in branches:
             if branch in self._branch_cache:
-                self._branch_cache[branch] = None
-                del self._branch_cache[branch]
-            elif branch in self._callable_cache:
-                self._callable_cache[branch] = None
-                del self._callable_cache[branch]
+                key = hashkey('BEvents._get_branch', branch)
+                self._branch_cache.popitem(key)
+            elif branch in self._nonbranch_cache:
+                self._nonbranch_cache.popitem(branch)

--- a/atuproot/BEvents.py
+++ b/atuproot/BEvents.py
@@ -110,12 +110,16 @@ class BEvents(object):
         return branch
 
     def hasbranch(self, branch):
-        return (branch in self.tree.keys() or branch in self._branch_cache or branch in self._nonbranch_cache)
+        return (
+            branch in self.tree.keys()
+            or hashkey('BEvents._get_branch', branch) in self._branch_cache
+            or branch in self._nonbranch_cache
+        )
 
     def delete_branches(self, branches):
         for branch in branches:
-            if branch in self._branch_cache:
-                key = hashkey('BEvents._get_branch', branch)
+            key = hashkey('BEvents._get_branch', branch)
+            if key in self._branch_cache:
                 self._branch_cache.popitem(key)
             elif branch in self._nonbranch_cache:
                 self._nonbranch_cache.popitem(branch)

--- a/atuproot/BEvents.py
+++ b/atuproot/BEvents.py
@@ -9,13 +9,13 @@ class BEvents(object):
         "_branch_cache", "_nonbranch_cache", "size", "config",
     ]
     def __init__(self, config):
-        self._branch_cache = config.get("branch_cache", {})
+        self._branch_cache = config.branch_cache
         self.tree = self._build_tree(config)
 
         self.nevents_in_tree = len(self.tree)
         self.nevents_per_block = (
-            int(config.get("nevents_per_block", 1_000_000))
-            if config.get("nevents_per_block", 1_000_000) >= 0 else
+            int(config.nevents_per_block)
+            if config.nevents_per_block >= 0 else
             self.nevents_in_tree
         )
 
@@ -35,8 +35,8 @@ class BEvents(object):
     def _build_tree(self, config):
         args = (config.inputPaths, config.treeName)
         kwargs = dict(
-            entrysteps=config.get("nevents_per_block", 1_000_000),
-            **config.get("uproot_kwargs", {}),
+            entrysteps=config.nevents_per_block,
+            **config.uproot_kwargs,
         )
 
         # Try to open the tree - some machines have configured limitations

--- a/atuproot/EventBuilder.py
+++ b/atuproot/EventBuilder.py
@@ -27,13 +27,15 @@ class EventBuilder(object):
         except mmap.error:
             def localsource(path):
                 return uproot.FileSource(path, **uproot.FileSource.defaults)
-            rootfile = uproot.open(self.config.inputPaths[0],
-                                   localsource = localsouce)
+            rootfile = uproot.open(
+                self.config.inputPaths[0],
+                localsource = lambda p: uproot.FileSource(p, **uproot.FileSource.defaults),
+            )
             tree = rootfile [self.config.treeName]
 
-        events = BEvents(tree,
-                         self.config.nevents_per_block,
-                         self.config.start_block,
-                         self.config.stop_block)
+        events = BEvents(
+            tree, self.config.nevents_per_block, self.config.start_block,
+            self.config.stop_block, branch_cache=self.config.branch_cache,
+        )
         events.config = self.config
         return events

--- a/atuproot/EventBuilder.py
+++ b/atuproot/EventBuilder.py
@@ -1,6 +1,3 @@
-import uproot
-import mmap
-
 from .BEvents import BEvents
 
 class EventBuilder(object):
@@ -14,28 +11,4 @@ class EventBuilder(object):
         )
 
     def __call__(self):
-        if len(self.config.inputPaths) != 1:
-            # TODO - support multiple inputPaths
-            raise AttributeError("Multiple inputPaths not yet supported")
-
-        # Try to open the tree - some machines have configured limitations
-        # which prevent memmaps from begin created. Use a fallback - the
-        # localsource option
-        try:
-            rootfile = uproot.open(self.config.inputPaths[0])
-            tree = rootfile[self.config.treeName]
-        except mmap.error:
-            def localsource(path):
-                return uproot.FileSource(path, **uproot.FileSource.defaults)
-            rootfile = uproot.open(
-                self.config.inputPaths[0],
-                localsource = lambda p: uproot.FileSource(p, **uproot.FileSource.defaults),
-            )
-            tree = rootfile [self.config.treeName]
-
-        events = BEvents(
-            tree, self.config.nevents_per_block, self.config.start_block,
-            self.config.stop_block, branch_cache=self.config.branch_cache,
-        )
-        events.config = self.config
-        return events
+        return BEvents(self.config)

--- a/atuproot/EventBuilderConfigMaker.py
+++ b/atuproot/EventBuilderConfigMaker.py
@@ -1,21 +1,23 @@
+import os
 import collections
 import uproot
 
 EventBuilderConfig = collections.namedtuple(
     'EventBuilderConfig',
-    'inputPaths treeName start_block stop_block nevents_per_block dataset name'
+    'inputPaths treeName start_block stop_block nevents_per_block dataset name branch_cache'
 )
 
 class EventBuilderConfigMaker(object):
     def __init__(
         self, nevents_per_block, treename_of_files_map={},
-        predetermined_nevents_in_file={},
+        predetermined_nevents_in_file={}, branch_cache={},
     ):
         self.nevents_per_block = nevents_per_block
         self._treename_of_files_map = treename_of_files_map
 
         # Cache nevents in each file - getting nevents takes a while
         self._nevents_in_file_cache = predetermined_nevents_in_file
+        self._branch_cache = branch_cache
 
     def create_config_for(self, dataset, files, start, length):
         config = EventBuilderConfig(
@@ -26,6 +28,7 @@ class EventBuilderConfigMaker(object):
             nevents_per_block = self.nevents_per_block,
             dataset = dataset,
             name = dataset.name,
+            branch_cache = self._branch_cache,
         )
         return config
 
@@ -35,6 +38,7 @@ class EventBuilderConfigMaker(object):
         return dataset.files[:min(maxFiles, len(dataset.files))]
 
     def nevents_in_file(self, path):
+        path = os.path.abspath(path)
         if path in self._nevents_in_file_cache:
             nblocks = self._nevents_in_file_cache[path]
         else:
@@ -44,7 +48,7 @@ class EventBuilderConfigMaker(object):
                 rootfile = uproot.open(path)
             except:
                 rootfile = uproot.open(path, localsource=uproot.FileSource.defaults)
-            nevents = len(rootfile[self._treename_of_files_map[path]])
+            nevents = rootfile[self._treename_of_files_map[path]].numentries
             nblocks = int((nevents-1) / self.nevents_per_block + 1)
             self._nevents_in_file_cache[path] = nblocks
         return nblocks

--- a/atuproot/atuproot_main.py
+++ b/atuproot/atuproot_main.py
@@ -20,22 +20,21 @@ logger.addHandler(handler)
 
 class AtUproot(object):
     def __init__(
-        self, outdir, quiet=False, parallel_mode='multiprocessing',
-        process=4, sge_opts="-q hep.q", max_blocks_per_dataset=-1,
-        max_blocks_per_process=-1, max_files_per_dataset=-1,
-        max_files_per_process=1, nevents_per_block=1000000, branch_cache={},
+        self, outdir, quiet=False,
+        max_blocks_per_dataset=-1, max_blocks_per_process=-1,
+        max_files_per_dataset=-1, max_files_per_process=1,
+        nevents_per_block=1000000,
+        branch_cache={},
     ):
-        self.parallel_mode = parallel_mode
-        self.sge_opts = sge_opts
-        self.ncores = process
+        self.outdir = outdir
         self.quiet = quiet
 
-        self.outdir = outdir
         self.max_blocks_per_dataset = max_blocks_per_dataset
         self.max_blocks_per_process = max_blocks_per_process
         self.max_files_per_dataset = max_files_per_dataset
         self.max_files_per_process = max_files_per_process
         self.nevents_per_block = nevents_per_block
+
         self.branch_cache = branch_cache
 
     def run(self, datasets, reader_collector_pairs):
@@ -64,18 +63,6 @@ class AtUproot(object):
         ]
 
         return tasks
-
-        if self.parallel_mode=="multiprocessing" and self.ncores==0:
-            results = pysge.local_submit(tasks)
-        elif self.parallel_mode=="multiprocessing":
-            results = pysge.mp_submit(tasks, ncores=self.ncores)
-        elif self.parallel_mode=="sge":
-            results = pysge.sge_submit(
-                    "zinv", "_ccsp_temp/", tasks=tasks,
-                options=self.sge_opts, sleep=5,
-                request_resubmission_options=True,
-            )
-        return results
 
     def _treename_of_files(self, datasets):
         return {

--- a/atuproot/atuproot_main.py
+++ b/atuproot/atuproot_main.py
@@ -24,7 +24,7 @@ class AtUproot(object):
         max_blocks_per_dataset=-1, max_blocks_per_process=-1,
         max_files_per_dataset=-1, max_files_per_process=1,
         nevents_per_block=1_000_000, profile=False, profile_out_path=None,
-        branch_cache={},
+        branch_cache={}, uproot_kwargs={},
     ):
         self.parallel = build_parallel(
             parallel_mode = parallel_mode,
@@ -45,6 +45,7 @@ class AtUproot(object):
         self.parallel_mode = parallel_mode
 
         self.branch_cache = branch_cache
+        self.uproot_kwargs = uproot_kwargs
 
     def run(self, datasets, reader_collector_pairs):
         self.parallel.begin()
@@ -79,6 +80,7 @@ class AtUproot(object):
             self.nevents_per_block,
             treename_of_files_map = self._treename_of_files(datasets),
             branch_cache = self.branch_cache,
+            uproot_kwargs = self.uproot_kwargs,
         )
         datasetIntoEventBuildersSplitter = DatasetIntoEventBuildersSplitter(
             EventBuilder = EventBuilder,

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", 'r') as fh:
 
 setuptools.setup(
     name = "atuproot",
-    version = "0.1.14",
+    version = "0.2.0",
     author = "Shane Breeze",
     author_email = "sdb15@ic.ac.uk",
     scripts = [],

--- a/setup.py
+++ b/setup.py
@@ -5,17 +5,15 @@ with open("README.md", 'r') as fh:
 
 setuptools.setup(
     name = "atuproot",
-    version = "0.1.13",
+    version = "0.1.14",
     author = "Shane Breeze",
     author_email = "sdb15@ic.ac.uk",
     scripts = [],
     description = "AlphaTwirl + uproot = FAST analysis code",
     long_description = long_description,
     long_description_content_type = "text/markdown",
-    url = "https://github.com/shane-breeze/atuproot",
-    download_url = "https://github.com/shane-breeze/atuproot/archive/0.1.13.tar.gz",
     packages = setuptools.find_packages(),
-    install_requires = ["six", "numpy", "alphatwirl>=0.20.1", "uproot>=2.9.7"],
+    install_requires = ["six", "numpy", "alphatwirl>=0.20.1", "uproot>=3.7.0rc1"],
     setup_requires = ["pytest-runner"],
     tests_require = ["pytest"],
     classifiers = (


### PR DESCRIPTION
Uses `uproot.lazyarrays`. `AtUproot` can be initialised with the kw argument `uproot_kwargs` which is passed to `uproot.lazyarrays` allowing the cache, profiles, ... to be set.

e.g.
```
AtUproot(..., uproot_kwargs={'profile': 'cms.nanoaod'}, ...)
```

Note that this will change naming conventions depending on the profile. Presumably a custom profile can be made?